### PR TITLE
replaced App::make() with app()

### DIFF
--- a/src/Domain/Model/DynamoDbModel.php
+++ b/src/Domain/Model/DynamoDbModel.php
@@ -117,7 +117,7 @@ abstract class DynamoDbModel extends Model
         // Initialize the client.
         if (static::$dynamoDb === null) {
             if ($dynamoDb === null) {
-                static::$dynamoDb = App::make('Nord\Lumen\DynamoDb\Contracts\DynamoDbClientInterface');
+                static::$dynamoDb = app('Nord\Lumen\DynamoDb\Contracts\DynamoDbClientInterface');
             } else {
                 static::$dynamoDb = $dynamoDb;
             }


### PR DESCRIPTION
Same as PR https://github.com/nordsoftware/lumen-dynamodb/pull/5 but to develop.

> If you run lumen without facades then you'll get an error that 'A facade root has not been set.'.

Closes #5.
