### PR TITLE
dirty attributes and exists flag

### DIFF
--- a/src/Domain/Model/DynamoDbModel.php
+++ b/src/Domain/Model/DynamoDbModel.php
@@ -183,6 +183,10 @@ abstract class DynamoDbModel extends Model
             $this->fireModelEvent('creating');
         }
 
+        if ($this->usesTimestamps()) {
+            $this->updateTimestamps();
+        }
+
         try {
             $this->client->putItem([
                 'TableName' => $this->getTable(),

--- a/src/Domain/Model/DynamoDbModel.php
+++ b/src/Domain/Model/DynamoDbModel.php
@@ -261,6 +261,8 @@ abstract class DynamoDbModel extends Model
         $model->fill($item);
         // Set the model id field.
         $model->setId($id);
+        $model->exists = true;
+        $model->syncOriginal();
 
         return $model;
     }
@@ -451,6 +453,9 @@ abstract class DynamoDbModel extends Model
             $item  = $this->unmarshalItem($item);
             $model = new static($item, static::$dynamoDb);
             $model->setUnfillableAttributes($item);
+            $model->exists = true;
+            $model->syncOriginal();
+
             $results[] = $model;
         }
 


### PR DESCRIPTION
after investigating why `protected $timestamps` member is not working: I realized that the attributes are filled but not synced into the `protected $original` state of the object, same appears to the `protected $exists` flag. 

additionally I added a auto-handling of `$timestamps` inside the `save` member.. 
